### PR TITLE
공격 단어, 단어 상태, 체력 구현에 대한 설명

### DIFF
--- a/src/game/game.rs
+++ b/src/game/game.rs
@@ -5,10 +5,9 @@ use rand::Rng;
 
 use ncurses::*;
 
+use super::game_state::GameState;
 use super::vocab::VocabGenerator;
 use super::word::Word;
-
-const MAX_WORDS: usize = 5;
 
 pub struct Game {
     score: i32,
@@ -21,6 +20,9 @@ pub struct Game {
     width: i32,
     vocab_generator: VocabGenerator,
     input_string: String,
+    life: i32,
+    game_state: GameState,
+    attack_string: String,
 }
 
 impl Game {
@@ -36,62 +38,57 @@ impl Game {
             width: width,
             vocab_generator: VocabGenerator::new(),
             input_string: String::new(),
+            life: 5,
+            game_state: GameState::StartGame,
+            attack_string: String::new(),
         }
     }
 
-    pub fn update(&mut self, input: Option<char>) -> bool {
-        self.spawn_word();
+    pub fn update(&mut self, input: Option<char>) {
+        if self.last_spawn_time.elapsed() > Duration::from_secs(2) {
+            self.spawn_word();
+            self.last_spawn_time = Instant::now();
+        }
         self.move_words();
 
-        let mut word_completed = false;
+        if self.attack_string.is_empty() {
+            self.attack_string = self.vocab_generator.generate();
+        }
 
-        if input.is_some() {
-            if input.unwrap() == '\n' {
-                for i in (0..self.words.len()).rev() {
-                    let word = &mut self.words[i];
-                    if self.input_string == word.get_text().clone() {
-                        self.score += word.get_text().len() as i32;
-                        self.words.remove(i);
-                        word_completed = true;
-                        break;
-                    }
-                }
-                self.input_string = String::new();
-            } else {
-                self.input_string.push(input.unwrap());
-            }
+        if input.is_some() && input.unwrap() != '\n' {
+            self.input_string.push(input.unwrap());
         }
 
         for i in (0..self.words.len()).rev() {
             let word = &mut self.words[i];
             word.set_y(word.get_y() + self.speed_factor);
 
-            if word.get_y() >= self.height as f32 {
+            let line = (self.height - 2) as f32;
+            if word.get_y() >= line {
                 self.score -= word.get_text().len() as i32;
                 self.words.remove(i);
+                self.life -= 1;
             }
         }
 
         if self.elapsed_time >= self.time_limit {
-            return false;
+            self.game_state = GameState::TimeOver;
+        }
+
+        if self.life <= 0 {
+            self.game_state = GameState::Lose;
         }
 
         self.elapsed_time += Duration::from_millis(100);
         self.speed_factor = 0.1 + self.score as f32 / 1000.0;
-
-        word_completed
     }
 
     fn spawn_word(&mut self) {
-        if self.words.len() < MAX_WORDS && self.last_spawn_time.elapsed() > Duration::from_secs(2) {
-            let mut rng = rand::thread_rng();
-            let word_text = self.vocab_generator.generate();
-            let word_x = rng.gen_range(0.0, self.width as f32 - word_text.len() as f32) as f32;
-            let word_y = 0.0;
-            self.words.push_back(Word::new(word_x, word_y, word_text));
-
-            self.last_spawn_time = Instant::now();
-        }
+        let mut rng = rand::thread_rng();
+        let word_text = self.vocab_generator.generate();
+        let word_x = rng.gen_range(0.0, self.width as f32 - word_text.len() as f32) as f32;
+        let word_y = 0.0;
+        self.words.push_back(Word::new(word_x, word_y, word_text));
     }
 
     pub fn move_words(&mut self) {
@@ -118,15 +115,41 @@ impl Game {
         (self.time_limit - self.elapsed_time).as_secs_f32()
     }
 
-    pub fn is_game_over(&self) -> bool {
-        self.elapsed_time >= self.time_limit
-    }
-
     pub fn get_input_string(&self) -> String {
         self.input_string.clone()
     }
 
-    pub fn backspace(&mut self) {
+    pub fn get_attack_string(&self) -> String {
+        self.attack_string.clone()
+    }
+
+    pub fn get_life(&self) -> i32 {
+        self.life
+    }
+
+    pub fn get_game_state(&self) -> GameState {
+        self.game_state
+    }
+
+    pub fn pop_input_string(&mut self) {
         self.input_string.pop();
+    }
+
+    pub fn enter_input_string(&mut self) {
+        for i in (0..self.words.len()).rev() {
+            let word = &mut self.words[i];
+            if self.input_string == word.get_text().clone() {
+                self.score += word.get_text().len() as i32;
+                self.words.remove(i);
+                self.game_state = GameState::Complete;
+                break;
+            }
+        }
+        if self.input_string == self.attack_string {
+            self.score += self.attack_string.len() as i32;
+            self.attack_string = self.vocab_generator.generate();
+            self.game_state = GameState::CompleteAttack;
+        }
+        self.input_string = String::new();
     }
 }

--- a/src/game/game_state.rs
+++ b/src/game/game_state.rs
@@ -1,8 +1,8 @@
 #[derive(Copy, Clone, PartialEq)]
 pub enum GameState {
     StartGame = 0,
-    Complete = 1,
-    CompleteAttack = 2,
+    CompleteWord = 1,
+    CompleteAttackWord = 2,
     Lose = 3,
-    TimeOver = 4,
+    InProgress = 4,
 }

--- a/src/game/game_state.rs
+++ b/src/game/game_state.rs
@@ -1,0 +1,8 @@
+#[derive(Copy, Clone, PartialEq)]
+pub enum GameState {
+    StartGame = 0,
+    Complete = 1,
+    CompleteAttack = 2,
+    Lose = 3,
+    TimeOver = 4,
+}

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -1,3 +1,4 @@
 pub mod game;
+pub mod game_state;
 mod vocab;
 mod word;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod game;
 
 use game::game::Game;
+use game::game_state::GameState;
 
 use ncurses::*;
 
@@ -18,25 +19,36 @@ fn main() {
     let line = "-".repeat(WIDTH as usize);
 
     loop {
-        let input = getch();
-
-        if input == KEY_F1 || game.is_game_over() {
-            break;
-        }
-        if input == KEY_BACKSPACE {
-            game.backspace();
-        }
         erase();
-
+        let input = getch();
         let input_char = if (input >= 0) && (input <= 255) {
             char::from_u32(input as u32)
         } else {
             None
         };
-        let word_completed = game.update(input_char);
-        if word_completed {
-            beep();
+
+        if input_char.is_some() {
+            if input == KEY_BACKSPACE
+                || input == KEY_DC
+                || input == 127
+                || input_char.unwrap() == '\u{0008}'
+            {
+                game.pop_input_string();
+            }
+            if input == KEY_ENTER || input == KEY_SEND || input_char.unwrap() == '\n' {
+                game.enter_input_string();
+            }
         }
+
+        game.update(input_char);
+        let game_state = game.get_game_state();
+
+        if game_state == GameState::Lose {
+            break;
+        };
+        if game_state == GameState::TimeOver {
+            break;
+        };
 
         addstr(&format!("Score: {}\n", game.get_score()));
         addstr(&format!("Time left: {:.1}s\n", game.get_time_left()));
@@ -44,16 +56,37 @@ fn main() {
 
         // Print input prompt
         let input_prompt = format!("> {}", game.get_input_string());
+        let life_string = format!("LIFE: {}", game.get_life());
+        let attack_string = format!("ATTACK: {}", game.get_attack_string());
 
+        mvprintw(0, WIDTH - life_string.len() as i32, &life_string);
+        mvprintw(1, WIDTH - attack_string.len() as i32, &attack_string);
         mvprintw(HEIGHT - 2, 0, &line);
         mvprintw(HEIGHT - 1, 0, input_prompt.as_str());
         refresh();
         napms(100);
     }
 
+    let game_result_str = if game.get_game_state() == GameState::Lose {
+        "YOU LOSE!\n"
+    } else {
+        "TIME OVER!\n"
+    };
+
+    addstr(game_result_str);
     addstr(&format!("Final Score: {}\n", game.get_score()));
+    refresh();
+
+    napms(1000);
     addstr("Press any key to exit...");
     refresh();
-    getch();
+
+    loop {
+        let input = getch();
+        if input > -1 {
+            break;
+        }
+        napms(100);
+    }
     endwin();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ fn main() {
 
     let mut game = Game::new(HEIGHT, WIDTH);
     let line = "-".repeat(WIDTH as usize);
+    let mut game_state = GameState::StartGame;
 
     loop {
         erase();
@@ -32,26 +33,29 @@ fn main() {
                 || input == KEY_DC
                 || input == 127
                 || input_char.unwrap() == '\u{0008}'
+                || input_char.unwrap() == '='
             {
                 game.pop_input_string();
             }
             if input == KEY_ENTER || input == KEY_SEND || input_char.unwrap() == '\n' {
-                game.enter_input_string();
+                game_state = game.enter_input_string();
             }
         }
 
-        game.update(input_char);
-        let game_state = game.get_game_state();
+        if game_state == GameState::CompleteAttackWord {
+            // TODO
+        }
+        // if Attacked {
+        //     game.spawn_word()
+        // }
+
+        game_state = game.update(input_char); // game_state = InProgress or Lose
 
         if game_state == GameState::Lose {
             break;
         };
-        if game_state == GameState::TimeOver {
-            break;
-        };
 
         addstr(&format!("Score: {}\n", game.get_score()));
-        addstr(&format!("Time left: {:.1}s\n", game.get_time_left()));
         game.draw_words();
 
         // Print input prompt
@@ -70,7 +74,7 @@ fn main() {
     let game_result_str = if game.get_game_state() == GameState::Lose {
         "YOU LOSE!\n"
     } else {
-        "TIME OVER!\n"
+        "YOU WIN!\n"
     };
 
     addstr(game_result_str);


### PR DESCRIPTION
This PR resolves #6

4월 27일 논의하였던 공격 단어, 단어 상태, 체력을 구현한 방식에 대한 설명입니다. 

### update()의 분할과 GameStatus, life 구현

코드를 작성하는 중에, `Game`의 `update()`가 너무 많은 일을 하고 있다는 생각이 들어 구조를 바꾸게 되었습니다.

먼저, 기존의 `update()`이 하였던 역할입니다.
1. 입력받은 `input`이 개행문자였는지 판단
2. 단어가 입력되면 `input_string`과 `words`를 순회 비교하여 일치할 경우 `words`에서 삭제
3. 단어가 삭제되었는지 여부를 boolean으로 반환
4. 단어가 line까지 내려왔을 경우 단어를 삭제하고 `score`를 단어의 길이만큼 감소

상기의 역할을 다음과 같이 재배치 하였습니다.
- 첫 번째 기능은 입출력과 관련된 부분이므로 main.rs에서 판단하도록 하였습니다.
- 두 번째 기능은 `Game.enter_input_string()`으로 분리하여 main.rs가 개행문자를 판단하면 호출하도록 하였습니다.
- 세 번째 기능은 `Game`이 GameState enum인 `game_state`를  갖도록 하여 get 메서드로 상태를 확인하도록 하였습니다.
- 네 번째 기능은 `Game`이 `life`를 갖도록 하여 `update()`가 원래 기능을 수행함과 동시에 `life`가 1 감소하도록 하였습니다.

game_state.rs 에는 GameState enum이 정의되어 있고, 다음과 같은 상태를 나타냅니다. 
- StartGame
- Complete
- CompleteAttack
- Lose
- TimeOver

`game_state`는 `update()`와 `enter_input_string()`에 의해 적절한 상태로 변화합니다. main.rs에서는 `update()`와 `enter_input_string()` 이 호출된 이후에 `get_game_state()`를 통해 현재 상태를 알 수 있습니다.

### 공격 단어 구현

![image](https://user-images.githubusercontent.com/38131725/235033041-1088d3b2-3aa6-4817-be11-05cb7ce4d809.png)

`Game`이 가지는 `attack_string` 은 테트리스의 HOLD처럼 화면 한 쪽에 고정된 위치에 등장하며, 한 번에 하나의 `attack_string`만 존재합니다. `attack_string`이 입력되면 다른 단어로 대체되고, `game_state`를 `CompleteAttack`으로 바꿉니다.

### 게임 종료

![image](https://user-images.githubusercontent.com/38131725/235038570-7ac705e4-cd29-49ae-bdd1-5ed0072f6885.png)
![image](https://user-images.githubusercontent.com/38131725/235038876-1eadb09f-0fb0-4ea5-a346-bd5222c8b360.png)

main.rs에서 `get_game_state`를 통해 게임이 종료되었다는 것을 감지하면, 게임 종료 화면을 출력합니다.

### 기존에 논의하였던 내용과 구현된 내용의 차이점

- 공격 단어가 붉은 색 단어로 떨어지는 형태가 아닙니다.
- 단어 상태가 아니라 게임 상태를 가지게 되었습니다.